### PR TITLE
Relative addressing for edits.

### DIFF
--- a/j.py
+++ b/j.py
@@ -570,9 +570,25 @@ class Journal:
         self._invoke_editor(tmp_paths, existing=True)
 
     def edit_entry(self, ident):
-        path = os.path.join(self.directory, ident)
-        entry = Entry(path)
-        self._edit_existing_entries([entry])
+        if ident.startswith("^"):
+            # Relative addressing.
+            filters = FilterSettings()
+            entries = self._collect_entries(bodies=False, filters=filters)
+
+            try:
+                idx = int(ident[1:])
+            except ValueError:
+                idx = -1
+
+            if idx < 0 or idx >= len(entries):
+                print("Invalid index")
+                sys.exit(1)
+
+            self._edit_existing_entries([entries[idx]])
+        else:
+            path = os.path.join(self.directory, ident)
+            entry = Entry(path)
+            self._edit_existing_entries([entry])
 
     def edit_tag(self, tag):
         filters = FilterSettings(tag_filters=[tag])
@@ -750,7 +766,8 @@ if __name__ == "__main__":
     edit_parser = subparsers.add_parser('edit', aliases=['e'])
     edit_parser.set_defaults(mode='edit')
     edit_parser.add_argument("arg", nargs="*",
-                             help="entry id or @tag to edit.")
+                             help="entry id or @tag to edit. "
+                                  "An id of '^N' edits the Nth newest entry.")
 
     show_parser = subparsers.add_parser('show', aliases=['s'])
     show_parser.set_defaults(mode='show')


### PR DESCRIPTION
This is a temproary fix until we have the '^N' system implemented as a
generic filter.

Then we can do (e.g.) `j s ^4` as well as `j e ^4`.